### PR TITLE
Added a few tests for events

### DIFF
--- a/codeweekeu/api/models/events.py
+++ b/codeweekeu/api/models/events.py
@@ -18,9 +18,9 @@ class Event(models.Model):
 	    ('REJECTED', 'Rejected'),
 	)
 	status = models.CharField(max_length=50, choices=STATUS_CHOICES, default='PENDING')
-	title = models.CharField(max_length=255)
+	title = models.CharField(max_length=255, default=None)
 	slug = models.SlugField(max_length=255, null=True, blank=True)
-	organizer = models.CharField(max_length=255)
+	organizer = models.CharField(max_length=255, default=None)
 	description = models.TextField(max_length=1000)
 	geoposition = GeopositionField()
 	location = models.CharField(max_length=1000)

--- a/codeweekeu/api/tests.py
+++ b/codeweekeu/api/tests.py
@@ -1,3 +1,23 @@
+import datetime
 from django.test import TestCase
+from api.models import Event
+from api.processors import get_pending_events
 
-# Create your tests here.
+class EventTestCase(TestCase):
+	def setUp(self):
+		Event.objects.create(organizer="asdasd",title="asdasd",
+							description="asdsad",location="asdsad",
+							start_date=datetime.datetime.now(),end_date=datetime.datetime.now(),
+							event_url="http://eee.com",contact_person="ss@ss.com",country="SI",
+							pub_date=datetime.datetime.now())
+
+	def test_get_approved_events(self):
+		test_event = Event.objects.get(title="asdasd")
+		self.assertEqual("PENDING", test_event.status)
+		test_event.status = "APPROVED"
+		test_event.save()
+		self.assertEqual("APPROVED", test_event.status)
+
+	def test_get_pending_events(self):
+		events = get_pending_events()
+		self.assertEqual(1, len(events))

--- a/codeweekeu/web/processors/event.py
+++ b/codeweekeu/web/processors/event.py
@@ -16,8 +16,8 @@ def get_country_from_user_ip(ip):
 	return g.country(ip)
 
 def get_event(event_id):
-    event = Event.objects.get(id=event_id)
-    return event
+	event = Event.objects.get(id=event_id)
+	return event
 
 def create_or_update_event(event_id=None, **event_data):
 	"""

--- a/codeweekeu/web/tests.py
+++ b/codeweekeu/web/tests.py
@@ -1,8 +1,8 @@
 import datetime
 from django.test import TestCase
-from api.models import Event
-from api.processors import get_pending_events
-
+from django.db import IntegrityError
+from models.events import Event
+from processors.event import get_event, create_or_update_event
 
 class EventTestCase(TestCase):
 	def setUp(self):
@@ -12,14 +12,39 @@ class EventTestCase(TestCase):
 							event_url="http://eee.com",contact_person="ss@ss.com",country="SI",
 							pub_date=datetime.datetime.now())
 
-	def test_get_approved_events(self):
+	def test_get_event(self):
 		test_event = Event.objects.get(title="asdasd")
-		self.assertEqual("PENDING", test_event.status)
-		test_event.status = "APPROVED"
-		test_event.save()
-		self.assertEqual("APPROVED", test_event.status)
+		self.assertEqual(test_event, get_event(event_id=1))
 
-	def test_get_pending_events(self):
-		events = get_pending_events()
-		self.assertEqual(1, len(events))
+	def test_create_or_update_event(self):
+		test_event = create_or_update_event(event_id=1)
+		self.assertEqual(1, test_event.id)
+
+	def test_create_event_without_args(self):
+		with self.assertRaises(IntegrityError):
+			test_event = create_or_update_event()
+
+	def test_create_event_with_title_only(self):
+		with self.assertRaises(IntegrityError):
+			test_event = create_or_update_event(title="event title")
+
+	def test_create_event_with_organizer_only(self):
+		with self.assertRaises(IntegrityError):
+			event_data = {"organizer":"asdasd"}
+			test_event = create_or_update_event(**event_data)
+
+
+	def test_create_event_with_start_end_dates_only(self):
+		with self.assertRaises(IntegrityError):
+			test_event = create_or_update_event(start_date=datetime.datetime.now(), end_date=datetime.datetime.now())
+
+
+	def test_create_event_from_dictionary_with_missing_required_fields(self):
+		with self.assertRaises(IntegrityError):
+			event_data = {
+				"end_date":datetime.datetime.now(),
+				"start_date":datetime.datetime.now(),
+				"organizer": "some organizer"
+				}
+			test_event = create_or_update_event(**event_data)
 


### PR DESCRIPTION
"Note that empty string values will always get stored as empty strings, not as NULL. Only use null=True for non-string fields such as integers, booleans and dates."

Added default values for organizer and title CharField to raise IntegrityError.
