### PR TITLE
fixing the see events in country button and country links

### DIFF
--- a/web/templates/pages/index.html
+++ b/web/templates/pages/index.html
@@ -57,7 +57,7 @@
 			</a>
 			<div id="allcountries" class="clearfix" style="display:none">
 				{% for each_country in all_countries %}
-					<a href="/{{each_country.1}}" class="country-link">
+					<a href="{% url 'web.index' each_country.1 %}" class="country-link">
 						<img src="/static/flags/{{ each_country.1|lower }}.gif" alt="{{ each_country.0 }}" />
 
 						<div class="icon-flag">


### PR DESCRIPTION
The script for showing/hiding list of countries was moved to a separate file, but the file wasn't linked in the template. Also, clicking on each country zooms in the map as before. The /view/country_code pages aren't working properly yet and it's much more attractive to get a view of the map with the markers.
