### PR TITLE
actually filling in the initial address when editing the event

### DIFF
--- a/static/js/events.js
+++ b/static/js/events.js
@@ -170,6 +170,7 @@ var Codeweek = window.Codeweek || {};
 
         $(function () {
             google.maps.event.addDomListener(window, 'load', function () {
+                address = document.getElementById('autocomplete').value;
                 initialize(address);
             });
 


### PR DESCRIPTION
This way the map will show the marker of the existing event address
