### PR TITLE
make search aware of past setting

### DIFF
--- a/web/templates/pages/index.html
+++ b/web/templates/pages/index.html
@@ -40,7 +40,7 @@
 			<div class="clearfix">
 				<div id="search-events-link">
 					<a class="btn btn-primary btn-lg"
-					   href="{% url 'web.search_events' %}?country_code={{ country.country_code }}">
+					   href="{% url 'web.search_events' %}?country_code={{ country.country_code }}&amp;past={{ past }}">
 						<i class="fa fa-list"></i> List all events {% if country %}in
 						<span id="country"> {{ country.country_name }}</span>{% endif %}
 					</a>

--- a/web/templates/pages/search_events.html
+++ b/web/templates/pages/search_events.html
@@ -51,7 +51,24 @@
 										{% include 'layout/event_tile_long.html' %}
 									{% endfor %}
 
-									{% show_pages %}
+									{% get_pages %}
+									{% if pages.paginated %}
+										<ul class="pagination">
+										<li>{{ pages.previous }}</li>
+										{% for page in pages %}
+											{% if page.is_current %}
+											<li class="active endless_page_current">
+											<a href="#">
+											{% else %}
+											<li>
+											<a href="{% url 'web.search_events' %}?past={% if past %}yes{% else %}no{% endif %}{% if page.url %}&amp;page={{ page.number }}{% endif %}" rel="page" class="endless_page_link">
+											{% endif %}
+											{{ page.number }}</a>
+											</li>
+										{% endfor %}
+										<li>{{ pages.next }}</li>
+										</ul>
+									{% endif %}
 
 								{% else %}
 									<h3>

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -261,6 +261,12 @@ def search_events(request):
 		country_code = request.GET.get('country_code', None)
 		country = get_country(country_code, user_ip)
 		events = get_approved_events(country_code=country)
+		
+		is_it_past = request.GET.get('past', 'no')
+		if is_it_past == 'yes':
+			past = True
+		else:
+			past = False
 
 		if request.method == 'POST':
 			form = SearchEventForm(request.POST)
@@ -274,15 +280,20 @@ def search_events(request):
 
 				events = get_filtered_events(search_filter, country_filter, theme_filter, audience_filter, past_events)
 				country = {'country_code': country_filter}
+
+				if past_events:
+					past = True
+				
 		else:
-			form = SearchEventForm(country_code=country['country_code'])
-			events = get_approved_events(country_code=country['country_code'])
+			form = SearchEventForm(country_code=country['country_code'],initial={'past_events': past})
+			events = get_approved_events(country_code=country['country_code'],past=past)
 
 		return render_to_response(
 			'pages/search_events.html', {
 				'events': events,
 				'form': form,
 			    'country': country['country_code'],
+			    'past': past,
 			}, context_instance=RequestContext(request))
 
 


### PR DESCRIPTION
Currently, search pagination links aren't able to take you to pages with past events. Likewise, clicking the search link on the index page doesn't take into account past settings. This Pull requests provides a temporary fix for these issues. A bit of spaghetti, so a better overall solution might be left for a refactlatlon.
