### PR TITLE
Making sure all div in spaghetti if-land are closed

### DIFF
--- a/web/templates/pages/view_event.html
+++ b/web/templates/pages/view_event.html
@@ -98,9 +98,9 @@
 				<a href="{% url 'web.edit_event' event.id %}" class="btn pull-right edit-event-btn">
 				<i class="fa fa-pencil-square-o"></i>Edit event</a>
 				{% if event.status == 'PENDING' %}
-							<div class="alert alert-warning">
-								<strong>NOTE:</strong> This event is stil being reviewed by <a href="{% url 'web.ambassadors' %}">moderators</a>.
-							</div>
+					<div class="alert alert-warning">
+						<strong>NOTE:</strong> This event is stil being reviewed by <a href="{% url 'web.ambassadors' %}">moderators</a>.
+					</div>
 				{% endif %}
 			{% endif %}
 			</div>


### PR DESCRIPTION
An unclosed `<div class="edit-toolbar">` was causing the Nearby events part to bleed into the footer. Should finally be all right now for different use cases (ambassador, creator, visitor ...)
