### PR TITLE
allow social auth users to change their first and last name

### DIFF
--- a/codeweekeu/settings.py
+++ b/codeweekeu/settings.py
@@ -528,6 +528,9 @@ COMPRESS_PRECOMPILERS = (
 )
 ########## END DJANGO COMRESSOR SETTINGS
 
+########## PYTHON SOCIAL AUTH
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['first_name', 'last_name']
+
 
 ########## TESTING
 TEST_RUNNER = 'django_pytest.test_runner.TestRunner'


### PR DESCRIPTION
But their email is overwritten (if available) - fixes #277 
