### PR TITLE
making sure existing image is not deleted upon save

### DIFF
--- a/web/templates/pages/add_event.html
+++ b/web/templates/pages/add_event.html
@@ -204,8 +204,9 @@
 							{{ form.picture.label }}
 						</label>
 
-						<div class="col-sm-9 first last fileinput {% if picture_url %}fileinput-exists{% else %}fileinput-new{% endif %} "
-						     data-provides="fileinput">
+						<div class="col-sm-9 first last fileinput {% if picture_url %}fileinput-exists{% else %}fileinput-new{% endif %}"
+						     data-provides="fileinput" data-name="{{ form.picture.name }}">
+						     <input type="hidden" name="{{ form.picture.name }}" value="nochange" />
 							<div class="fileinput-new">
 								<img src="{% static 'img/image_placeholder.png' %}" alt="Image Placeholder"
 								     style="max-height: 204px; max-width: 100%">
@@ -221,7 +222,7 @@
 							<span class="btn btn-sm btn-file">
 								<span class="fileinput-new">Select image</span>
 								<span class="fileinput-exists">Change</span>
-								<input type="file" name="{{ form.picture.name }}"/></span>
+								<input type="file"/></span>
 								<a href="#" class="btn btn-sm fileinput-exists" data-dismiss="fileinput">Remove</a>
 							</div>		
 						</div>

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -140,11 +140,13 @@ def edit_event(request, event_id):
 	else:
 		event_form = AddEventForm(initial=initial)
 
-
+	existing_picture = event.picture
+	
 	if event_form.is_valid():
+		# picture_check works with jasny bootstrap magix
+		picture_check = request.POST.get('picture')
 		picture = request.FILES.get('picture', None)
 		event_data = event_form.cleaned_data
-
 		event_data['creator'] = request.user
 
 		# checking if user entered a different email than in her profile
@@ -156,8 +158,9 @@ def edit_event(request, event_id):
 			if picture:
 				if picture.size > (256 * 1024):
 					raise ImageSizeTooLargeException('Image size too large.')
-
 				event_data['picture'] = process_image(picture)
+			elif picture_check == "nochange":
+				event_data['picture'] = existing_picture
 			else:
 				del event_data['picture']
 


### PR DESCRIPTION
Fixes #298 by implementing recommendations from http://www.jasny.net/articles/jasny-bootstrap-file-upload-with-existing-file/ and an additional check in the edit_event view. The chance detects event events that don't touch the image, making sure it's not deleted unless the user clicks the Remove option.
