### PR TITLE
add creator email link to approved event notice

### DIFF
--- a/web/templates/pages/view_event.html
+++ b/web/templates/pages/view_event.html
@@ -64,7 +64,14 @@
 							This event is nice and approved. You can revert it to
 							<a href="{% url 'web.change_status' event.pk %}">
 								<strong>pending</strong> 
-							</a> or check other
+							</a>
+
+							{% if event.creator.email %}, contact the event creator 
+							<a href="mailto:{{event.creator.email}}?subject=Your Code Week event">
+								by email
+							</a>{% endif %}
+
+							 or check other
 							<a href="{% url 'web.pending_events' user.profile.country %}">
 								<strong>pending events</strong>
 							</a>.
@@ -75,7 +82,7 @@
 							{% endif %}
 						</div>
 					{% elif event.status == 'REJECTED' %}
-						<div class="alert alert-info">
+						<div class="alert alert-danger">
 							This event is rejected. You can revert it to
 							<a href="{% url 'web.reject_status' event.pk %}">
 								<strong>pending</strong> 


### PR DESCRIPTION
... and changed the alert box color for rejected events, so it stands out from approved events. Changes requested by Ambassadors.
