### PR TITLE
Fix for missing location - ouyeah

### DIFF
--- a/static/js/events.js
+++ b/static/js/events.js
@@ -131,6 +131,7 @@ var Codeweek = window.Codeweek || {};
 		var geoLatLng = autocomplete.getPlace().geometry.location;
 	
 		createMarker(geoLatLng);
+		updateLatLng(geoLatLng.lat(), geoLatLng.lng());
 		updateAddress(geoLatLng);
 	}
 


### PR DESCRIPTION
I was able to reproduce the zero lat, lng issue #308 in Firefox with browser language set to Slovenian and sometimes even in Chrome with language set to Slovenian (as a primary browser language). For some unknown reasons everything worked fine in Chrome when language was set to English. 

Anyway, the issue was a missing call to update longitude and latitude ( issue #336 ). After adding this call I haven't been able to reproduce the issue again, so I think it is safe to assume it is fixed... for now. :)

@goranche It is already _tomorrow_ now. :cat: 

![Events in the sea](https://cloud.githubusercontent.com/assets/1309114/4380880/6d7c5556-436e-11e4-948a-7d5694b49205.png)
