### PR TITLE
This should fix the 'list all events in ...' button issue

### DIFF
--- a/web/processors/event.py
+++ b/web/processors/event.py
@@ -12,6 +12,8 @@ from mailer.event_report_mailer import send_email_to_country_ambassadors
 
 
 def get_client_ip(forwarded=None, remote=None):
+	if settings.DEBUG and remote == '127.0.0.1':
+		return '93.103.53.11'
 	if forwarded:
 		return forwarded.split(',')[0]
 	return remote


### PR DESCRIPTION
We removed the override of the IP in DEBUG mode, which caused localhost to not be associated with a country...
the code now checks for DEBUG and if the remote address is localhost (127.0.0.1) it returns a slovene address
