### PR TITLE
Changed the text in add event template. Fixed saving of contact person e-mail address

### DIFF
--- a/web/forms/event_form.py
+++ b/web/forms/event_form.py
@@ -148,6 +148,9 @@ class AddEventForm(forms.ModelForm):
 			msg = u'End date should be greater than start date.'
 			self._errors['end_date'] = self.error_class([msg])
 
+		# Set contact_person e-mail in Event model ('user_email' is used to update the User model)
+		cleaned_data['contact_person'] = cleaned_data.get('user_email', '')
+
 		return cleaned_data
 
 	def __init__(self, *args, **kwargs):

--- a/web/templates/pages/add_event.html
+++ b/web/templates/pages/add_event.html
@@ -235,7 +235,7 @@
 				<h3>Your contact information</h3>
 				<div class="aluminum">
 					This information will only be visible to
-					<a href="{% url 'web.ambassadors' %}" target="_blank">EU Code Week Ambassadors</a>, who will check your event before it appears on the map and might contact you if edits are necessary.
+					<a href="{% url 'web.ambassadors' %}" target="_blank">EU Code Week Ambassadors</a> and Code Week organizers, who will check your event before it appears on the map and might contact you if edits are necessary or for administering surveys for statistical purposes after the event.
 				</div>
 				<div class="col-md-6 first">
 					<div class="form-group {% if form.user_email.errors %}has-error{% endif %}">


### PR DESCRIPTION
Trello issue: "Add a new private email field (to be contacted by Code Week organizers and ambassadors for statistics and approval purposes) to the event form and make it required."