### PR TITLE
Add active countries filter for scoreboard

### DIFF
--- a/web/processors/event.py
+++ b/web/processors/event.py
@@ -142,7 +142,7 @@ def count_approved_events_for_country(past=True):
 	for country in list(countries)[2:]:
 		country_code = country[0]
 		country_name = country[1]
-		number_of_events = all_events.filter(country=country_code).count()
+		number_of_events = all_events.filter(country=country_code).filter(start_date__gte=datetime.date(2014,1,1)).count()
 		population = Country.objects.get(iso=country_code).population
 		country_score = 0
 		if number_of_events > 0 and population > 0 and population != "":
@@ -151,7 +151,8 @@ def count_approved_events_for_country(past=True):
 						'country_name': country_name, 
 						'events': number_of_events,
 						'score': country_score}
-		country_count.append(country_entry)
+		if number_of_events > 0:
+			country_count.append(country_entry)
 
 	sorted_count = sorted(country_count, key=lambda k: k['score'], reverse=True)
 	return sorted_count

--- a/web/tests/test_events_processors.py
+++ b/web/tests/test_events_processors.py
@@ -471,9 +471,8 @@ def test_scoreboard_counter(admin_user, db):
 	initial_counter = count_approved_events_for_country()
 
 	# extra check to make sure the number of results matches 
-	# the number of listed countries minus two custom entries
-	all_countries = list_countries()
-	assert len(initial_counter) == len(all_countries[2:])
+	# the number of active countries
+	assert len(initial_counter) == 0
 
 	counted_events_before = 0
 


### PR DESCRIPTION
This patch should filter the entries in scoreboard to show only countries with `numbers_of_event > 0`
I got trouble in running the test in my local environment, so let's see if is all ok with *Travis CI*.

Your choice if merge or not this patch.