### PR TITLE
Fix for the top menu hover shading problem

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -107,3 +107,7 @@ ul.nav.navbar-nav li a{
     width: auto;
     margin: 0 auto;
 }
+
+#page-menu nav li, #page-menu nav li a{
+    height: 100%;
+}

--- a/static/scss/_scoreboard.scss
+++ b/static/scss/_scoreboard.scss
@@ -5,7 +5,7 @@ SCOREBOARD STYLES
 .sb-wrapper {
 	display: block;
 	position: relative;
-	z-index: 999;
+	z-index: 0;
 	padding: 0 25px;
 	overflow: visible;
 

--- a/web/templates/pages/login.html
+++ b/web/templates/pages/login.html
@@ -17,7 +17,8 @@
                             <span>To prevent spam, we require a login before adding an event.</span>
                         </div>
                         <div class="modal" id="login-modal-open" role="dialog" aria-labelledby="opened-login-window"
-			     aria-hidden="false" style="display: block !important; position: relative; overflow: hidden;">
+			     aria-hidden="false" style="display: block !important; position:
+			     relative; overflow: hidden; z-index: 0">
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">


### PR DESCRIPTION
Hi guys,
I was adding an event today and saw two little problems with the design. 
I am sending fixes for them.

In the page submenu, there is a problem on hover, where shading does not meet the height of the menu.
![europe code week map of events](https://cloud.githubusercontent.com/assets/2290441/10142882/9f7967ae-6615-11e5-8bc0-bbb0f618e462.png)

The other error is that modal window on the login page overflows the main menu.
![europe code week login](https://cloud.githubusercontent.com/assets/2290441/10142855/6fbf0a82-6615-11e5-82e5-5f0da3540a3f.png)

I have also added a fix for the scoreboard rendering, which is also overflowing the menu.
![europe code week events scoreboard](https://cloud.githubusercontent.com/assets/2290441/10143205/3c01ca84-6617-11e5-878a-a4ed6427b07e.png)


Thanks,
Erika
