### PR TITLE
Add support to main contact and secondary ambassadors

### DIFF
--- a/api/migrations/0009_auto__add_field_userprofile_role__add_field_userprofile_is_main_contac.py
+++ b/api/migrations/0009_auto__add_field_userprofile_role__add_field_userprofile_is_main_contac.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'UserProfile.role'
+        db.add_column(u'api_userprofile', 'role',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+        # Adding field 'UserProfile.is_main_contact'
+        db.add_column(u'api_userprofile', 'is_main_contact',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'UserProfile.role'
+        db.delete_column(u'api_userprofile', 'role')
+
+        # Deleting field 'UserProfile.is_main_contact'
+        db.delete_column(u'api_userprofile', 'is_main_contact')
+
+
+    models = {
+        'api.event': {
+            'Meta': {'ordering': "['start_date']", 'object_name': 'Event'},
+            'audience': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'event_audience'", 'symmetrical': 'False', 'to': "orm['api.EventAudience']"}),
+            'contact_person': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'max_length': '1000'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'event_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'geoposition': ('geoposition.fields.GeopositionField', [], {'default': "'0,0'", 'max_length': '42'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': '1000'}),
+            'organizer': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '255'}),
+            'picture': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2015, 9, 29, 0, 0)'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '50'}),
+            'theme': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'event_theme'", 'symmetrical': 'False', 'to': "orm['api.EventTheme']"}),
+            'title': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'api.eventaudience': {
+            'Meta': {'object_name': 'EventAudience'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'api.eventtheme': {
+            'Meta': {'ordering': "['order', 'name']", 'object_name': 'EventTheme'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'api.socialaccountlist': {
+            'Meta': {'object_name': 'SocialAccountList'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        'api.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'bio': ('django.db.models.fields.TextField', [], {'max_length': '1000', 'blank': 'True'}),
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_main_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'role': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '140', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['api']

--- a/api/models/users.py
+++ b/api/models/users.py
@@ -14,6 +14,8 @@ class UserProfile(models.Model):
     bio = models.TextField(max_length=1000, blank=True)
     website = models.URLField(blank=True)
     twitter = models.CharField(max_length=140, blank=True)
+    role = models.CharField(max_length=255, blank=True, default='')
+    is_main_contact = models.BooleanField(default=False)
 
     def __unicode__(self):
         return 'Username: %s, First Name:%s Last Name: %s, Country: %s, Bio: %s, Website: %s, Twitter: %s' % (

--- a/web/processors/user.py
+++ b/web/processors/user.py
@@ -31,16 +31,16 @@ def get_ambassadors_for_countries():
     # list countries minus two CUSTOM_COUNTRY_ENTRIES
     for code, name in list(countries)[2:]:
         readable_name = unicode(name)
-        # TODO: load main ambassadors
-        main_ambassadors =  []
-        # TODO: exclude main ambassadors
-        found_ambassadors = [ambassador for ambassador in ambassadors if ambassador.country == code]
+        country_ambassadors = [ambassador for ambassador in ambassadors if ambassador.country == code]
+        # load main ambassadors
+        main_ambassadors =  [ambassador for ambassador in country_ambassadors if ambassador.is_main_contact]
+        # exclude main ambassadors
+        found_ambassadors = [ambassador for ambassador in country_ambassadors if not ambassador.is_main_contact]
         countries_ambassadors.append(
             (code, readable_name, found_ambassadors, main_ambassadors))
 
     countries_ambassadors.sort()
     return countries_ambassadors
-
 
 def get_ambassadors_for_country(country):
     ambassadors = User.objects.filter(

--- a/web/templates/pages/ambassadors.html
+++ b/web/templates/pages/ambassadors.html
@@ -19,23 +19,6 @@
                 {% if user_country %}Your current country: <a href="http://events.codeweek.eu/ambassadors">{{ user_country.country_name }}</a>{% endif %}
             </div>
     <div class="tabs clearfix" id="tab-1" data-active="{{ country_pos }}">
-        <div id="showcountries">
-            <ul class="clearfix list-style-none">
-				{% for each_country in all_countries %}
-                    <li><a href="#tabs-{{ each_country.1 }}">
-						<div class="country-link" data-name="{{ each_country.0 }}">
-                            
-							<img src="/static/flags/{{ each_country.1|lower }}.png" alt="{{ each_country.0 }}" />
-
-							<div class="country-name">
-								{{ each_country.0 }}
-							</div>
-                        </div>
-                    </a></li>
-					{% endfor %}
-
-            </ul>
-            </div>
             <div class="tab-container">
 		      {% for code,country,ambassadors, mains in countries %}
                 <div class="tab-content clearfix" id="tabs-{{ code }}">
@@ -132,11 +115,28 @@
                     
                     {% endfor %}
                     {% else %}
-                    <p>No ambassador yet. Why don't you <a href="mailto:europecodes@gmail.com">volunteer</a>?</p>
+                    <p style="text-align: center">No ambassador yet. Why don't you <a href="mailto:europecodes@gmail.com">volunteer</a>?</p>
                     {% endif %}
                 </div>
 
 		      {% endfor %}
+            </div>
+        <div id="showcountries">
+            <ul class="clearfix list-style-none">
+				{% for each_country in all_countries %}
+                    <li><a href="#tabs-{{ each_country.1 }}">
+						<div class="country-link" data-name="{{ each_country.0 }}">
+                            
+							<img src="/static/flags/{{ each_country.1|lower }}.png" alt="{{ each_country.0 }}" />
+
+							<div class="country-name">
+								{{ each_country.0 }}
+							</div>
+                        </div>
+                    </a></li>
+					{% endfor %}
+
+            </ul>
             </div>
 	</div>
 


### PR DESCRIPTION
In order to update the database the following commands are to be executed:

    ./manage.py schemamigration api --auto
    ./manage.py migrate api

The `role` and `is_main_contact` field can be manipolated from the `Api -> User profiles` section of the admin interface.

I moved the contacts information in the top of the page as suggested by Alessandro Bogliolo. I leave further template changes to you.

Also improved the test implemented in 2b429ea8af4de0a5876b937