### PR TITLE
Scoreboard score and event concact emails fixed

### DIFF
--- a/web/processors/event.py
+++ b/web/processors/event.py
@@ -150,7 +150,7 @@ def count_approved_events_for_country(past=True):
         number_of_events = all_events.filter(
             country=country_code).filter(
             start_date__gte=datetime.date(
-                2014, 1, 1)).count()
+                datetime.datetime.now().year, 1, 1)).count()
         population = Country.objects.get(iso=country_code).population
         country_score = 0
         if number_of_events > 0 and population > 0 and population != "":


### PR DESCRIPTION
Scoreboard is now related to 2015+ event count instead of 2014+ event density.

As in the request from Alessandro Bogliolo:

"There is a pending task opened by Annika (EU Commission): having a
scoreboard based on the number of events (rather than on the density) filtered
in order to consider only the events with start date in 2015:
http://events.codeweek.eu/scoreboard/ "